### PR TITLE
Add VASCO SecureClick

### DIFF
--- a/70-u2f.rules
+++ b/70-u2f.rules
@@ -37,4 +37,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="24dc", ATTRS{idProduct
 # U2F Zero
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="8acf", TAG+="uaccess"
 
+# VASCO SecureClick
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1a44", ATTRS{idProduct}=="00bb", TAG+="uaccess"
+
 LABEL="u2f_end"


### PR DESCRIPTION
VASCO SecureClick does not document how to use their product. Nota Bene: This only works after you successfully paired a SecureClick token to the USB bridge using a [Chrome app](https://chrome.google.com/webstore/detail/digipass-secureclick-mana/gjbcaijefcocakonhdnfhomcnlcppbcg) -- on the linux side, after successful pairing, `idProduct` changes from `80bb` to `00bb`.